### PR TITLE
Feat/social login: 소셜로그인, 로그인페이지 레이아웃 임시 배치

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from 'next/font/local';
 import './globals.css';
 import Providers from '@/app/provider';
 import Header from '@/components/layouts/Header';
+import Footer from '@/components/layouts/Footer';
 
 const geistSans = localFont({
   src: './fonts/GeistVF.woff',
@@ -27,10 +28,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='en'>
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}>
         <Providers>
           <Header />
-          {children}
+          <main className='h-full flex-1 px-[16px]'>{children}</main>
+          <Footer />
         </Providers>
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import './globals.css';
 import Providers from '@/app/provider';
+import Header from '@/components/layouts/Header';
 
 const geistSans = localFont({
   src: './fonts/GeistVF.woff',
@@ -27,7 +28,10 @@ export default function RootLayout({
   return (
     <html lang='en'>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <Providers>{children}</Providers>
+        <Providers>
+          <Header />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,21 +1,30 @@
 'use client';
 
 import { createClient } from '@/utils/supabase/client';
-
 const SignInPage = () => {
   const client = createClient();
-
   const handleGoogleSignIn = () => {
     client.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: 'http://localhost:3000/auth/callback',
+        redirectTo: window.origin + '/auth/callback',
       },
     });
   };
+
+  const handleKakaoSignIn = async () => {
+    await client.auth.signInWithOAuth({
+      provider: 'kakao',
+      options: {
+        redirectTo: window.origin + '/auth/callback',
+      },
+    });
+  };
+
   return (
     <div>
       <button onClick={handleGoogleSignIn}>구글 로그인</button>
+      <button onClick={handleKakaoSignIn}>카카오 로그인</button>
     </div>
   );
 };

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -22,9 +22,29 @@ const SignInPage = () => {
   };
 
   return (
-    <div>
-      <button onClick={handleGoogleSignIn}>구글 로그인</button>
-      <button onClick={handleKakaoSignIn}>카카오 로그인</button>
+    <div className='flex flex-col items-center'>
+      <div className='bg-amber-300 w-[88px] h-[88px] my-[80px]'>로고</div>
+      <section className='flex flex-col items-center gap-[16px] w-full'>
+        <button
+          className='w-full h-[56px] border rounded'
+          onClick={handleKakaoSignIn}
+        >
+          카카오로 시작하기
+        </button>
+        <button
+          className='w-full h-[56px] border rounded'
+          onClick={handleGoogleSignIn}
+        >
+          구글로 시작하기
+        </button>
+        <p>또는</p>
+        <button
+          className='w-full h-[56px] border rounded'
+          onClick={() => alert('아직 준비중인 기능입니다')}
+        >
+          이메일로 시작하기
+        </button>
+      </section>
     </div>
   );
 };

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,26 +1,7 @@
 'use client';
+import { handleGoogleSignIn, handleKakaoSignIn } from '@/utils/supabase/signIn';
 
-import { createClient } from '@/utils/supabase/client';
 const SignInPage = () => {
-  const client = createClient();
-  const handleGoogleSignIn = () => {
-    client.auth.signInWithOAuth({
-      provider: 'google',
-      options: {
-        redirectTo: window.origin + '/auth/callback',
-      },
-    });
-  };
-
-  const handleKakaoSignIn = async () => {
-    await client.auth.signInWithOAuth({
-      provider: 'kakao',
-      options: {
-        redirectTo: window.origin + '/auth/callback',
-      },
-    });
-  };
-
   return (
     <div className='flex flex-col items-center'>
       <div className='bg-amber-300 w-[88px] h-[88px] my-[80px]'>로고</div>

--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -1,0 +1,5 @@
+const Footer = () => {
+  return <footer className='bg-amber-200 h-[50px]'>임시 footer 영역</footer>;
+};
+
+export default Footer;

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,12 +1,13 @@
 import { createClient } from '@/utils/supabase/server';
 import Navigation from '@/components/layouts/Navigation';
 import Link from 'next/link';
+import { UserData } from '@/types/supabaseMethod.types';
 
 const Header = async () => {
   const client = createClient();
-  const { data } = await client.auth.getUser();
+  const { data }: UserData = await client.auth.getUser();
 
-  let isAuthenticated = false;
+  let isAuthenticated: boolean = false;
   if (data.user) {
     isAuthenticated = true;
   }

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,5 +1,6 @@
 import { createClient } from '@/utils/supabase/server';
 import Navigation from '@/components/layouts/Navigation';
+import Link from 'next/link';
 
 const Header = async () => {
   const client = createClient();
@@ -11,7 +12,8 @@ const Header = async () => {
   }
 
   return (
-    <header>
+    <header className='w-full h-[64px] bg-gray-400 flex justify-around items-center'>
+      <Link href='/'>BI</Link>
       <Navigation isAuthenticated={isAuthenticated} />
     </header>
   );

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,0 +1,20 @@
+import { createClient } from '@/utils/supabase/server';
+import Navigation from '@/components/layouts/Navigation';
+
+const Header = async () => {
+  const client = createClient();
+  const { data } = await client.auth.getUser();
+
+  let isAuthenticated = false;
+  if (data.user) {
+    isAuthenticated = true;
+  }
+
+  return (
+    <header>
+      <Navigation isAuthenticated={isAuthenticated} />
+    </header>
+  );
+};
+
+export default Header;

--- a/src/components/layouts/Navigation.tsx
+++ b/src/components/layouts/Navigation.tsx
@@ -1,19 +1,13 @@
 'use client';
 import Link from 'next/link';
-import { createClient } from '@/utils/supabase/client';
-import { useRouter } from 'next/navigation';
-import useSignOut from '@/hooks/auth/useSignOut';
 
 const Navigation = ({ isAuthenticated }: { isAuthenticated: boolean }) => {
-  const { handleSignOut } = useSignOut();
-
   return (
     <div>
       <Link href='/review'>후기</Link>
       {isAuthenticated ? (
         <>
           <Link href='/mypage'>마이페이지</Link>
-          <button onClick={handleSignOut}>로그아웃</button>
         </>
       ) : (
         <Link href='/signin'>로그인</Link>

--- a/src/components/layouts/Navigation.tsx
+++ b/src/components/layouts/Navigation.tsx
@@ -1,0 +1,29 @@
+'use client';
+import Link from 'next/link';
+import { createClient } from '@/utils/supabase/client';
+import { useRouter } from 'next/navigation';
+
+const Navigation = ({ isAuthenticated }: { isAuthenticated: boolean }) => {
+  const client = createClient();
+  const router = useRouter();
+
+  const handleSignOut = async () => {
+    await client.auth.signOut();
+    router.refresh();
+  };
+
+  return (
+    <div>
+      {isAuthenticated ? (
+        <>
+          <Link href='/mypage'>마이페이지</Link>
+          <button onClick={handleSignOut}>로그아웃</button>
+        </>
+      ) : (
+        <Link href='/signin'>로그인</Link>
+      )}
+    </div>
+  );
+};
+
+export default Navigation;

--- a/src/components/layouts/Navigation.tsx
+++ b/src/components/layouts/Navigation.tsx
@@ -2,18 +2,14 @@
 import Link from 'next/link';
 import { createClient } from '@/utils/supabase/client';
 import { useRouter } from 'next/navigation';
+import useSignOut from '@/hooks/auth/useSignOut';
 
 const Navigation = ({ isAuthenticated }: { isAuthenticated: boolean }) => {
-  const client = createClient();
-  const router = useRouter();
-
-  const handleSignOut = async () => {
-    await client.auth.signOut();
-    router.refresh();
-  };
+  const { handleSignOut } = useSignOut();
 
   return (
     <div>
+      <Link href='/review'>후기</Link>
       {isAuthenticated ? (
         <>
           <Link href='/mypage'>마이페이지</Link>

--- a/src/components/layouts/Navigation.tsx
+++ b/src/components/layouts/Navigation.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 const Navigation = ({ isAuthenticated }: { isAuthenticated: boolean }) => {
   return (
-    <div>
+    <div className='flex gap-3'>
       <Link href='/review'>후기</Link>
       {isAuthenticated ? (
         <>

--- a/src/hooks/auth/useSignOut.ts
+++ b/src/hooks/auth/useSignOut.ts
@@ -1,0 +1,16 @@
+import { createClient } from '@/utils/supabase/client';
+import { useRouter } from 'next/navigation';
+
+const useSignOut = () => {
+  const client = createClient();
+  const router = useRouter();
+
+  const handleSignOut = async () => {
+    await client.auth.signOut();
+    router.refresh();
+  };
+
+  return { handleSignOut };
+};
+
+export default useSignOut;

--- a/src/types/supabaseMethod.types.ts
+++ b/src/types/supabaseMethod.types.ts
@@ -1,0 +1,4 @@
+import { AuthUser } from '@supabase/supabase-js';
+
+// auth.getUser() 반환 타입
+export type UserData = { data: { user: AuthUser | null } };

--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -1,10 +1,8 @@
-import { createBrowserClient } from "@supabase/ssr";
+import { createBrowserClient } from '@supabase/ssr';
+import { Database } from '@/types/database.types';
 
 export const createClient = () =>
-    createBrowserClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-    );
+  createBrowserClient<Database>(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);
 
 const browserClient = createClient();
 

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,38 +1,39 @@
-import { createServerClient } from "@supabase/ssr";
-import { cookies } from "next/headers";
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { Database } from '@/types/database.types';
 
 export const createClient = () => {
-    const cookieStore = cookies();
+  const cookieStore = cookies();
 
-    return createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-        {
-            cookies: {
-                getAll() {
-                    return cookieStore.getAll();
-                },
-                setAll(cookiesToSet) {
-                    try {
-                        cookiesToSet.forEach(({ name, value, options }) => {
-                            cookieStore.set(name, value, options);
-                        });
-                    } catch (error) {
-                        // The `set` method was called from a Server Component.
-                        // This can be ignored if you have middleware refreshing
-                        // user sessions.
-                        console.error(error);
-                    }
-                },
-            },
-        }
-    );
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options);
+            });
+          } catch (error) {
+            // The `set` method was called from a Server Component.
+            // This can be ignored if you have middleware refreshing
+            // user sessions.
+            console.error(error);
+          }
+        },
+      },
+    },
+  );
 };
 
 export const getIsLogin = async () => {
-    const serverClient = createClient();
-    const {
-        data: { session },
-    } = await serverClient.auth.getSession();
-    return !!session;
+  const serverClient = createClient();
+  const {
+    data: { session },
+  } = await serverClient.auth.getSession();
+  return !!session;
 };

--- a/src/utils/supabase/signIn.ts
+++ b/src/utils/supabase/signIn.ts
@@ -1,0 +1,31 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@/utils/supabase/client';
+
+const client: SupabaseClient = createClient();
+export const handleGoogleSignIn: () => Promise<void> = async () => {
+  try {
+    await client.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: window.origin + '/auth/callback',
+      },
+    });
+  } catch (error) {
+    console.error('Google login failed: ', error);
+    alert('구글 로그인에 문제가 발생했습니다. 잠시 후 다시 시도해주세요.');
+  }
+};
+
+export const handleKakaoSignIn: () => Promise<void> = async () => {
+  try {
+    await client.auth.signInWithOAuth({
+      provider: 'kakao',
+      options: {
+        redirectTo: window.origin + '/auth/callback',
+      },
+    });
+  } catch (error) {
+    console.error('Kakao signIn failed: ', error);
+    alert('카카오 로그인에 문제가 발생했습니다. 잠시 후 다시 시도해주세요. ');
+  }
+};


### PR DESCRIPTION
## ✅ 작업 사항

- 구글로그인, 카카오로그인 추가
- 이메일로그인 버튼만 배치 + 클릭시 준비중인 기능이라는 alert 임시로 넣어뒀습니다
- 유저 인증 상태에따른 네비게이션 메뉴 변경
- 전체 적용 레이아웃 설정 (footer 가장 아래로, 양옆 padding 16px)


## 📸 스크린샷
![소셜로그인](https://github.com/user-attachments/assets/3a4c67fe-77e2-43c5-bff9-bcb8f53dbd22)

<br/>

## 🧑‍💻 기타

- (공유한 내용) 유저 상태 zustand로 관리하지 않고 getSession, getUser로 받아와 사용하기로 결정!
