### PR TITLE
Feat/invitation: 청첩장 미리보기, 비공개 설정 시 보이지 않도록 구현

### DIFF
--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    await revalidatePath(`/card/${id}`);
+    revalidatePath(`/card/${id}`);
     return NextResponse.json({ revalidated: true });
   } catch (error) {
     console.error('Error revalidating:', error);

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+
+  if (!id) {
+    return NextResponse.json({ message: '청첩장 ID가 필요합니다.' }, { status: 400 });
+  }
+
+  try {
+    await revalidatePath(`/card/${id}`);
+    return NextResponse.json({ revalidated: true });
+  } catch (error) {
+    console.error('Error revalidating:', error);
+    return NextResponse.json({ message: '청첩장 캐시 업데이트에 문제가 생겼습니다.' }, { status: 500 });
+  }
+}

--- a/src/app/card/[id]/page.tsx
+++ b/src/app/card/[id]/page.tsx
@@ -4,6 +4,10 @@ import { convertToCamelCase } from '@/utils/convert/invitaitonTypeConvert';
 import MainPhoto from '@/components/card/MainPhoto';
 import Greeting from '@/components/card/Greeting';
 import PersonalInfoOnSharedCard from '@/components/card/PersonalInfoOnSharedCard';
+import Account from '@/components/card/Account';
+import WeddingInfo from '@/components/card/WeddingInfo';
+import NavigationDetails from '@/components/card/NavigationDetails';
+import GuestInfo from '@/components/card/GuestInfo';
 
 export const generateStaticParams = async () => {
   const { data } = await supabase.from('invitation').select('id');
@@ -34,13 +38,13 @@ const CardPage = async ({ params }: { params: { id: string } }) => {
     // imgRatio,
     // mainText,
     greetingMessage,
-    // guestbook,
-    // attendance,
+    guestbook,
+    attendance,
     personalInfo,
-    // weddingInfo,
-    // account,
-    // navigationDetail,
-    // dDay,
+    weddingInfo,
+    account,
+    navigationDetail,
+    dDay,
     mainPhotoInfo,
     isPrivate,
   } = convertToCamelCase(invitation);
@@ -57,6 +61,18 @@ const CardPage = async ({ params }: { params: { id: string } }) => {
       />
       <Greeting greetingMessage={greetingMessage} />
       <PersonalInfoOnSharedCard personalInfo={personalInfo} />
+      <Account account={account} />
+      <WeddingInfo weddingInfo={weddingInfo} />
+      <NavigationDetails
+        navigationDetail={navigationDetail}
+        weddingInfo={weddingInfo}
+      />
+      <GuestInfo
+        attendance={attendance}
+        guestbook={guestbook}
+        dDay={dDay}
+        weddingInfo={weddingInfo}
+      />
     </div>
   );
 };

--- a/src/app/card/[id]/page.tsx
+++ b/src/app/card/[id]/page.tsx
@@ -1,5 +1,27 @@
-const CardPage = () => {
-  return <div></div>;
+import { notFound } from 'next/navigation';
+import { supabase } from '@/utils/supabase/createClient';
+
+export const generateStaticParams = async () => {
+  const { data } = await supabase.from('invitation').select('id');
+  return (
+    data?.map((invitation) => ({
+      id: invitation.id,
+    })) || []
+  );
+};
+
+const fetchInvitationData = async (id: string) => {
+  const { data, error } = await supabase.from('invitation').select('*').eq('id', id).single();
+
+  if (error || !data) notFound();
+
+  return data;
+};
+
+const CardPage = async ({ params }: { params: { id: string } }) => {
+  const { isPrivate } = await fetchInvitationData(params.id);
+
+  return <div>{isPrivate ? <div>아직 공개되지 않은 청첩장입니다.</div> : <div>청첩장 내용</div>}</div>;
 };
 
 export default CardPage;

--- a/src/app/card/[id]/page.tsx
+++ b/src/app/card/[id]/page.tsx
@@ -8,6 +8,7 @@ import Account from '@/components/card/Account';
 import WeddingInfo from '@/components/card/WeddingInfo';
 import NavigationDetails from '@/components/card/NavigationDetails';
 import GuestInfo from '@/components/card/GuestInfo';
+import WeddingGallery from '@/components/card/WeddingGallery';
 
 export const generateStaticParams = async () => {
   const { data } = await supabase.from('invitation').select('id');
@@ -29,14 +30,10 @@ const fetchInvitationData = async (id: string) => {
 const CardPage = async ({ params }: { params: { id: string } }) => {
   const invitation = await fetchInvitationData(params.id);
   const {
-    // gallery,
-    // type,
-    // mood,
+    gallery,
     mainView,
     bgColor,
     stickers,
-    // imgRatio,
-    // mainText,
     greetingMessage,
     guestbook,
     attendance,
@@ -59,6 +56,7 @@ const CardPage = async ({ params }: { params: { id: string } }) => {
         mainView={mainView}
         stickers={stickers}
       />
+      <WeddingGallery gallery={gallery} />
       <Greeting greetingMessage={greetingMessage} />
       <PersonalInfoOnSharedCard personalInfo={personalInfo} />
       <Account account={account} />

--- a/src/app/card/[id]/page.tsx
+++ b/src/app/card/[id]/page.tsx
@@ -1,5 +1,9 @@
 import { notFound } from 'next/navigation';
 import { supabase } from '@/utils/supabase/createClient';
+import { convertToCamelCase } from '@/utils/convert/invitaitonTypeConvert';
+import MainPhoto from '@/components/card/MainPhoto';
+import Greeting from '@/components/card/Greeting';
+import PersonalInfoOnSharedCard from '@/components/card/PersonalInfoOnSharedCard';
 
 export const generateStaticParams = async () => {
   const { data } = await supabase.from('invitation').select('id');
@@ -19,9 +23,42 @@ const fetchInvitationData = async (id: string) => {
 };
 
 const CardPage = async ({ params }: { params: { id: string } }) => {
-  const { isPrivate } = await fetchInvitationData(params.id);
+  const invitation = await fetchInvitationData(params.id);
+  const {
+    // gallery,
+    // type,
+    // mood,
+    mainView,
+    bgColor,
+    stickers,
+    // imgRatio,
+    // mainText,
+    greetingMessage,
+    // guestbook,
+    // attendance,
+    personalInfo,
+    // weddingInfo,
+    // account,
+    // navigationDetail,
+    // dDay,
+    mainPhotoInfo,
+    isPrivate,
+  } = convertToCamelCase(invitation);
 
-  return <div>{isPrivate ? <div>아직 공개되지 않은 청첩장입니다.</div> : <div>청첩장 내용</div>}</div>;
+  return isPrivate ? (
+    <div>아직 공개되지 않은 청첩장입니다.</div>
+  ) : (
+    <div>
+      <MainPhoto
+        mainPhotoInfo={mainPhotoInfo}
+        bgColor={bgColor}
+        mainView={mainView}
+        stickers={stickers}
+      />
+      <Greeting greetingMessage={greetingMessage} />
+      <PersonalInfoOnSharedCard personalInfo={personalInfo} />
+    </div>
+  );
 };
 
 export default CardPage;

--- a/src/components/attendance/AttendanceButton.tsx
+++ b/src/components/attendance/AttendanceButton.tsx
@@ -2,10 +2,12 @@
 
 import useAttendanceButton from '@/hooks/attendance/useAttendanceButton';
 import AttendanceModal from './AttendanceModal';
+import { usePathname } from 'next/navigation';
+import useInvitationIdByPathname from '@/hooks/invitation/useInvitationIdByPathname';
 
 const AttendanceButton = () => {
+  const { invitationId } = useInvitationIdByPathname();
   const { showModal, handleModalClick } = useAttendanceButton();
-  const invitationId = '6ae529a2-725d-4e2d-ac26-07bd9e86aa34'; // @TODO 추후 청첩장 id를 넣는 방식으로 변경
 
   return (
     <>

--- a/src/components/attendance/AttendanceButton.tsx
+++ b/src/components/attendance/AttendanceButton.tsx
@@ -2,7 +2,6 @@
 
 import useAttendanceButton from '@/hooks/attendance/useAttendanceButton';
 import AttendanceModal from './AttendanceModal';
-import { usePathname } from 'next/navigation';
 import useInvitationIdByPathname from '@/hooks/invitation/useInvitationIdByPathname';
 
 const AttendanceButton = () => {

--- a/src/components/card/Account.tsx
+++ b/src/components/card/Account.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { InvitationFormType } from '@/types/invitationFormType.type';
+import { useEffect, useState } from 'react';
+import { AccountType } from '@/types/accountType.type';
+import { createPortal } from 'react-dom';
+import AccountModal from '@/components/create/modal/AccountModal';
+
+type AccountPropType = Pick<InvitationFormType, 'account'>;
+const Account = ({ account }: AccountPropType) => {
+  const [openAccountModal, setOpenAccountModal] = useState<boolean>(false);
+  const [portalElement, setPortalElement] = useState<Element | null>(null);
+  const [accountData, setAccountData] = useState<AccountType[]>([]);
+  const [accountType, setAccountType] = useState<'groom' | 'bride'>('groom');
+  useEffect(() => {
+    setPortalElement(document.getElementById('modal'));
+  }, []);
+  const handleOpenAccountModal = (type: 'bride' | 'groom') => {
+    setOpenAccountModal(true);
+    if (type === 'bride') {
+      const brideAccounts = account.bride;
+      setAccountData(brideAccounts);
+      setAccountType('bride');
+    }
+    if (type === 'groom') {
+      const groomAccounts = account.groom;
+      setAccountData(groomAccounts);
+      setAccountType('groom');
+    }
+  };
+  return (
+    <div className='flex flex-col justify-center items-center'>
+      <p className='text-xl'>{account.title ? account.title : '제목'}</p>
+      <p className=''>{account.content ? account.content : '내용'}</p>
+      <div className='flex flex-col gap-5 mt-5 w-full justify-center items-center'>
+        <button
+          className='rounded-full border-2 w-[343px] h-[48px]'
+          onClick={() => handleOpenAccountModal('groom')}
+        >
+          신랑 측 계좌번호
+        </button>
+        <button
+          className='rounded-full border-2 w-[343px] h-[48px]'
+          onClick={() => handleOpenAccountModal('bride')}
+        >
+          신부 측 계좌번호
+        </button>
+      </div>
+      {openAccountModal && portalElement
+        ? createPortal(
+            <AccountModal
+              setOpenAccountModal={setOpenAccountModal}
+              accounts={accountData}
+              accountType={accountType}
+            />,
+            portalElement,
+          )
+        : null}
+    </div>
+  );
+};
+
+export default Account;

--- a/src/components/card/Greeting.tsx
+++ b/src/components/card/Greeting.tsx
@@ -1,0 +1,17 @@
+import { InvitationFormType } from '@/types/invitationFormType.type';
+
+type GreetingPropType = Pick<InvitationFormType, 'greetingMessage'>;
+const Greeting = ({ greetingMessage }: GreetingPropType) => {
+  return (
+    <div className='text-black  flex flex-col justify-center items-center'>
+      {!greetingMessage.title ? <p>제목을 입력해주세요</p> : <p>{greetingMessage.title}</p>}
+      <div
+        dangerouslySetInnerHTML={{
+          __html: greetingMessage?.content || '대표문구를 작성해주세요',
+        }}
+      ></div>
+    </div>
+  );
+};
+
+export default Greeting;

--- a/src/components/card/GuestInfo.tsx
+++ b/src/components/card/GuestInfo.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { InvitationFormType } from '@/types/invitationFormType.type';
+import GuestBook from '@/components/guestbook/GuestBook';
+import EventStatus from '@/components/create/EventStatus';
+
+type GuestInfoPropType = Pick<InvitationFormType, 'attendance' | 'guestbook' | 'dDay' | 'weddingInfo'>;
+const GuestInfo = ({ attendance, guestbook, dDay, weddingInfo }: GuestInfoPropType) => {
+  return (
+    <>
+      {guestbook && <GuestBook />}
+      <EventStatus
+        attendanceButton={attendance}
+        dDayCount={dDay}
+        weddingInfoDate={weddingInfo.date}
+      />
+    </>
+  );
+};
+
+export default GuestInfo;

--- a/src/components/card/MainPhoto.tsx
+++ b/src/components/card/MainPhoto.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import Image from 'next/image';
+import { ArchSvg, EllipseSvg } from '@/components/create/CustomSVG';
+import Sticker from '@/components/create/stickerInput/Sticker';
+import { useRef, useState } from 'react';
+import { InvitationFormType, StickerType } from '@/types/invitationFormType.type';
+import { usePathname } from 'next/navigation';
+import StickerOnSharedCard from '@/components/card/StickerOnSharedCard';
+
+const preventDefaultBehaviour = (e: React.DragEvent<HTMLDivElement>) => {
+  e.preventDefault();
+  e.stopPropagation();
+};
+
+type MainPhotoPropType = Pick<InvitationFormType, 'mainPhotoInfo' | 'bgColor' | 'mainView' | 'stickers'>;
+
+const MainPhoto = ({ mainPhotoInfo, bgColor, mainView, stickers }: MainPhotoPropType) => {
+  const previewRef = useRef<HTMLDivElement | null>(null);
+  const [activeStickerId, setActiveStickerId] = useState<string | null>(null);
+  const handleActiveSticker = (id?: string) => {
+    setActiveStickerId(id || null);
+  };
+  const path = usePathname();
+
+  return (
+    <div className='w-full flex flex-col justify-center item-center mx-auto text-center text-black'>
+      <div
+        className='quill-preview'
+        dangerouslySetInnerHTML={{
+          __html: mainPhotoInfo?.introduceContent || '대표문구를 작성해주세요',
+        }}
+      />
+      <div className={`flex justify-center items-center w-full ${mainView.type === 'fill' ? 'px-0' : 'px-[20px]'} `}>
+        {!mainPhotoInfo?.imageUrl ? (
+          <p className='text-gray-500 w-[375px] h-[728px] bg-gray text-center'>이미지가 업로드되지 않았습니다.</p>
+        ) : (
+          <div
+            className='flex justify-center items-center relative w-full h-[600px]'
+            ref={previewRef}
+            onDrop={preventDefaultBehaviour}
+            onDragOver={preventDefaultBehaviour}
+          >
+            <Image
+              src={mainPhotoInfo.imageUrl}
+              alt='mainImg'
+              objectFit='cover'
+              fill
+              className='z-0'
+            />
+            <div className='absolute inset-0 flex justify-center items-center'>
+              {mainView.type === 'arch' && <ArchSvg color={bgColor} />}
+              {mainView.type === 'ellipse' && <EllipseSvg color={bgColor} />}
+            </div>
+            {path === '/create/card'
+              ? stickers?.map((sticker: StickerType) => (
+                  <Sticker
+                    key={sticker.id}
+                    sticker={sticker}
+                    previewRef={previewRef}
+                    activeStickerId={activeStickerId}
+                    onActivate={handleActiveSticker}
+                  />
+                ))
+              : stickers?.map((sticker: StickerType) => (
+                  <StickerOnSharedCard
+                    key={sticker.id}
+                    sticker={sticker}
+                  />
+                ))}
+          </div>
+        )}
+      </div>
+      <div className='flex justify-center items-center gap-2 mt-4'>
+        <p className='text-xl'>{mainPhotoInfo?.leftName || '좌측 이름'}</p>
+        <p className='text-xl'>{mainPhotoInfo?.icon || '♥︎'}</p>
+        <p className='text-xl'>{mainPhotoInfo?.rightName || '우측 이름'}</p>
+      </div>
+    </div>
+  );
+};
+
+export default MainPhoto;

--- a/src/components/card/NavigationDetails.tsx
+++ b/src/components/card/NavigationDetails.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { InvitationFormType } from '@/types/invitationFormType.type';
+import MapView from '@/components/map/MapView';
+import NavigationButtons from '@/components/create/NavigationButtons';
+import NavigationDetailCard from '@/components/create/NavigationDetailCard';
+
+type NavigationDetailsPropType = Pick<InvitationFormType, 'navigationDetail' | 'weddingInfo'>;
+const NavigationDetails = ({ navigationDetail, weddingInfo }: NavigationDetailsPropType) => {
+  return (
+    <>
+      <div>NavigationDetailsPreview</div>
+      {navigationDetail.map && <MapView address={weddingInfo.weddingHallAddress} />}
+      {navigationDetail.navigationButton && (
+        <NavigationButtons
+          address={weddingInfo.weddingHallAddress}
+          name={weddingInfo.weddingHallName}
+        />
+      )}
+      {navigationDetail.bus && (
+        <NavigationDetailCard
+          label={'버스'}
+          info={navigationDetail.bus}
+        />
+      )}
+      {navigationDetail.subway && (
+        <NavigationDetailCard
+          label={'지하철'}
+          info={navigationDetail.subway}
+        />
+      )}
+    </>
+  );
+};
+
+export default NavigationDetails;

--- a/src/components/card/PersonalInfoOnSharedCard.tsx
+++ b/src/components/card/PersonalInfoOnSharedCard.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { InvitationFormType } from '@/types/invitationFormType.type';
+import PersonalInfoCard from '@/components/create/PersonalInfoCard';
+
+type PersonalInfoOnSharedCardPropsType = Pick<InvitationFormType, 'personalInfo'>;
+const PersonalInfoOnSharedCard = ({ personalInfo }: PersonalInfoOnSharedCardPropsType) => {
+  const { bride, groom } = personalInfo;
+
+  return (
+    <div className='flex flex-col justify-center items-center gap-[30px]'>
+      <div className='flex gap-[50px]'>
+        <div className='flex flex-col gap-[30px]'>
+          <div className='flex flex-col justify-center items-center'>
+            <PersonalInfoCard
+              label={groom.relation}
+              name={groom.name}
+              phoneNumber={groom.phoneNumber}
+            />
+          </div>
+          <p className='text-center'>신랑 측 혼주</p>
+          <PersonalInfoCard
+            label={groom.father.relation}
+            name={groom.father.isDeceased ? `故 ${groom.father.name}` : groom.father.name}
+            phoneNumber={groom.father.phoneNumber}
+          />
+          <PersonalInfoCard
+            label={groom.mother.relation}
+            name={groom.mother.isDeceased ? `故 ${groom.mother.name}` : groom.mother.name}
+            phoneNumber={groom.mother.phoneNumber}
+          />
+        </div>
+
+        <div className='flex flex-col gap-[30px]'>
+          <div className='flex flex-col justify-center items-center'>
+            <PersonalInfoCard
+              label={bride.relation}
+              name={bride.name}
+              phoneNumber={bride.phoneNumber}
+            />
+          </div>
+          <p className='text-center'>신부 측 혼주</p>
+          <PersonalInfoCard
+            label={bride.father.relation}
+            name={bride.father.isDeceased ? `故 ${bride.father.name}` : bride.father.name}
+            phoneNumber={bride.father.phoneNumber}
+          />
+          <PersonalInfoCard
+            label={bride.mother.relation}
+            name={bride.mother.isDeceased ? `故 ${bride.mother.name}` : bride.mother.name}
+            phoneNumber={bride.mother.phoneNumber}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PersonalInfoOnSharedCard;

--- a/src/components/card/StickerOnSharedCard.tsx
+++ b/src/components/card/StickerOnSharedCard.tsx
@@ -1,0 +1,20 @@
+import { StickerType } from '@/types/invitationFormType.type';
+import Image from 'next/image';
+
+const StickerOnSharedCard = ({ sticker }: { sticker: StickerType }) => {
+  return (
+    <Image
+      src={sticker.url}
+      alt=''
+      width={sticker.width}
+      height={sticker.height}
+      style={{
+        position: 'absolute',
+        top: `${sticker.posY}%`,
+        left: `${sticker.posX}%`,
+      }}
+    />
+  );
+};
+
+export default StickerOnSharedCard;

--- a/src/components/card/WeddingGallery.tsx
+++ b/src/components/card/WeddingGallery.tsx
@@ -1,0 +1,37 @@
+import { InvitationFormType } from '@/types/invitationFormType.type';
+import Image from 'next/image';
+
+type GalleryPropType = Pick<InvitationFormType, 'gallery'>;
+const WeddingGallery = ({ gallery }: GalleryPropType) => {
+  const gridType = gallery?.grid;
+  const ratio = gallery?.ratio;
+
+  const imgStyleClass = ratio === 'rectangle' ? 'w-full h-[500px]' : 'w-full h-full';
+
+  const gridClass = gridType === 3 ? 'grid grid-cols-3 gap-2' : 'grid grid-cols-2 gap-2';
+
+  return (
+    <div className={`${gridClass} p-2`}>
+      {gallery && gallery.images.length > 0 ? (
+        gallery.images.map((image, i) => (
+          <div
+            key={image}
+            className={`relative ${ratio === 'rectangle' ? 'aspect-[9/14]' : 'aspect-square'}`}
+          >
+            <Image
+              src={image}
+              alt={`galleryImage${i}`}
+              className={imgStyleClass}
+              layout='fill'
+              objectFit='cover'
+            />
+          </div>
+        ))
+      ) : (
+        <div>업로드 된 사진이 없습니다.</div>
+      )}
+    </div>
+  );
+};
+
+export default WeddingGallery;

--- a/src/components/card/WeddingInfo.tsx
+++ b/src/components/card/WeddingInfo.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { InvitationFormType } from '@/types/invitationFormType.type';
+
+type WeddingInfoPropType = Pick<InvitationFormType, 'weddingInfo'>;
+const WeddingInfo = ({ weddingInfo }: WeddingInfoPropType) => {
+  return (
+    <div>
+      웨딩 정보 입력 미리보기 영역
+      <p>날짜: {weddingInfo?.date}</p>
+      <p>{weddingInfo.time.hour}시</p>
+      <p>{weddingInfo.time.minute}분</p>
+      <p>예식장 주소: {weddingInfo.weddingHallAddress}</p>
+      <p>예식장 이름: {weddingInfo.weddingHallName}</p>
+      <p>연락처: {weddingInfo.weddingHallContact}</p>
+    </div>
+  );
+};
+
+export default WeddingInfo;

--- a/src/components/create/preview/AccountPreView.tsx
+++ b/src/components/create/preview/AccountPreView.tsx
@@ -1,65 +1,14 @@
 'use client';
 import { Control, useWatch } from 'react-hook-form';
 import { InvitationFormType } from '@/types/invitationFormType.type';
-import { useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
-import AccountModal from '../modal/AccountModal';
-import { AccountType } from '@/types/accountType.type';
+import Account from '@/components/card/Account';
 
 const AccountPreView = ({ control }: { control: Control<InvitationFormType> }) => {
-  const [openAccountModal, setOpenAccountModal] = useState<boolean>(false);
-  const [portalElement, setPortalElement] = useState<Element | null>(null);
-  const [accountData, setAccountData] = useState<AccountType[]>([]);
-  const [accountType, setAccountType] = useState<'groom' | 'bride'>('groom');
-  const accountWatch = useWatch({
+  const account = useWatch({
     control,
     name: 'account',
   });
-  useEffect(() => {
-    setPortalElement(document.getElementById('modal'));
-  }, []);
-  const handleOpenAccountModal = (type: 'bride' | 'groom') => {
-    setOpenAccountModal(true);
-    if (type === 'bride') {
-      const brideAccounts = accountWatch.bride;
-      setAccountData(brideAccounts);
-      setAccountType('bride');
-    }
-    if (type === 'groom') {
-      const groomAccounts = accountWatch.groom;
-      setAccountData(groomAccounts);
-      setAccountType('groom');
-    }
-  };
-  return (
-    <div className='flex flex-col justify-center items-center'>
-      <p className='text-xl'>{accountWatch.title ? accountWatch.title : '제목'}</p>
-      <p className=''>{accountWatch.content ? accountWatch.content : '내용'}</p>
-      <div className='flex flex-col gap-5 mt-5 w-full justify-center items-center'>
-        <button
-          className='rounded-full border-2 w-[343px] h-[48px]'
-          onClick={() => handleOpenAccountModal('groom')}
-        >
-          신랑 측 계좌번호
-        </button>
-        <button
-          className='rounded-full border-2 w-[343px] h-[48px]'
-          onClick={() => handleOpenAccountModal('bride')}
-        >
-          신부 측 계좌번호
-        </button>
-      </div>
-      {openAccountModal && portalElement
-        ? createPortal(
-            <AccountModal
-              setOpenAccountModal={setOpenAccountModal}
-              accounts={accountData}
-              accountType={accountType}
-            />,
-            portalElement,
-          )
-        : null}
-    </div>
-  );
+
+  return <Account account={account} />;
 };
 export default AccountPreView;

--- a/src/components/create/preview/GalleryPreview.tsx
+++ b/src/components/create/preview/GalleryPreview.tsx
@@ -1,6 +1,6 @@
 import { InvitationFormType } from '@/types/invitationFormType.type';
 import { Control, useWatch } from 'react-hook-form';
-import Image from 'next/image';
+import WeddingGallery from '@/components/card/WeddingGallery';
 
 const GalleryPreview = ({ control }: { control: Control<InvitationFormType> }) => {
   const gallery = useWatch({
@@ -8,35 +8,7 @@ const GalleryPreview = ({ control }: { control: Control<InvitationFormType> }) =
     name: 'gallery',
   });
 
-  const gridType = gallery?.grid;
-  const ratio = gallery?.ratio;
-
-  const imgStyleClass = ratio === 'rectangle' ? 'w-full h-[500px]' : 'w-full h-full';
-
-  const gridClass = gridType === 3 ? 'grid grid-cols-3 gap-2' : 'grid grid-cols-2 gap-2';
-
-  return (
-    <div className={`${gridClass} p-2`}>
-      {gallery && gallery.images.length > 0 ? (
-        gallery.images.map((image, i) => (
-          <div
-            key={image}
-            className={`relative ${ratio === 'rectangle' ? 'aspect-[9/14]' : 'aspect-square'}`}
-          >
-            <Image
-              src={image}
-              alt={`galleryImage${i}`}
-              className={imgStyleClass}
-              layout='fill'
-              objectFit='cover'
-            />
-          </div>
-        ))
-      ) : (
-        <div>업로드 된 사진이 없습니다.</div>
-      )}
-    </div>
-  );
+  return <WeddingGallery gallery={gallery} />;
 };
 
 export default GalleryPreview;

--- a/src/components/create/preview/GreetingPreview.tsx
+++ b/src/components/create/preview/GreetingPreview.tsx
@@ -1,5 +1,6 @@
 import { InvitationFormType } from '@/types/invitationFormType.type';
 import { Control, useWatch } from 'react-hook-form';
+import Greeting from '@/components/card/Greeting';
 
 const GreetingPreview = ({ control }: { control: Control<InvitationFormType> }) => {
   const greetingMessage = useWatch({
@@ -7,16 +8,7 @@ const GreetingPreview = ({ control }: { control: Control<InvitationFormType> }) 
     name: 'greetingMessage',
   });
 
-  return (
-    <div className='text-black  flex flex-col justify-center items-center'>
-      {!greetingMessage.title ? <p>제목을 입력해주세요</p> : <p>{greetingMessage.title}</p>}
-      <div
-        dangerouslySetInnerHTML={{
-          __html: greetingMessage?.content || '대표문구를 작성해주세요',
-        }}
-      ></div>
-    </div>
-  );
+  return <Greeting greetingMessage={greetingMessage} />;
 };
 
 export default GreetingPreview;

--- a/src/components/create/preview/GuestInfoPreview.tsx
+++ b/src/components/create/preview/GuestInfoPreview.tsx
@@ -1,36 +1,33 @@
 'use client';
 
-import GuestBook from '@/components/guestbook/GuestBook';
 import { Control, useWatch } from 'react-hook-form';
 import { InvitationFormType } from '@/types/invitationFormType.type';
-import EventStatus from '../EventStatus';
+import GuestInfo from '@/components/card/GuestInfo';
 
 const GuestInfoPreview = ({ control }: { control: Control<InvitationFormType> }) => {
-  const attendanceButton = useWatch({
+  const attendance = useWatch({
     control,
     name: 'attendance',
   });
-  const guestBookButton = useWatch({
+  const guestbook = useWatch({
     control,
     name: 'guestbook',
   });
-  const dDayCount = useWatch({
+  const dDay = useWatch({
     control,
     name: 'dDay',
   });
-  const weddingInfoDate = useWatch({
+  const weddingInfo = useWatch({
     control,
     name: 'weddingInfo',
   });
   return (
-    <>
-      {guestBookButton && <GuestBook />}
-      <EventStatus
-        attendanceButton={attendanceButton}
-        dDayCount={dDayCount}
-        weddingInfoDate={weddingInfoDate.date}
-      />
-    </>
+    <GuestInfo
+      attendance={attendance}
+      guestbook={guestbook}
+      dDay={dDay}
+      weddingInfo={weddingInfo}
+    />
   );
 };
 

--- a/src/components/create/preview/MainPhotoPreView.tsx
+++ b/src/components/create/preview/MainPhotoPreView.tsx
@@ -1,14 +1,6 @@
 import { InvitationFormType } from '@/types/invitationFormType.type';
-import Image from 'next/image';
 import { Control, useWatch } from 'react-hook-form';
-import { ArchSvg, EllipseSvg } from '../CustomSVG';
-import { useRef, useState } from 'react';
-import Sticker from '@/components/create/stickerInput/Sticker';
-
-const preventDefaultBehaviour = (e: React.DragEvent<HTMLDivElement>) => {
-  e.preventDefault();
-  e.stopPropagation();
-};
+import MainPhoto from '@/components/card/MainPhoto';
 
 const MainPhotoPreView = ({ control }: { control: Control<InvitationFormType> }) => {
   const mainPhotoInfo = useWatch({
@@ -26,67 +18,18 @@ const MainPhotoPreView = ({ control }: { control: Control<InvitationFormType> })
     name: 'mainView',
   });
 
-  const stickersWatch = useWatch({
+  const stickers = useWatch({
     control,
     name: 'stickers',
   });
 
-  const previewRef = useRef<HTMLDivElement | null>(null);
-
-  const [activeStickerId, setActiveStickerId] = useState<string | null>(null);
-  const handleActiveSticker = (id?: string) => {
-    setActiveStickerId(id || null);
-  };
-
   return (
-    <div className='w-full flex flex-col justify-center item-center mx-auto text-center text-black'>
-      <div
-        className='quill-preview'
-        dangerouslySetInnerHTML={{
-          __html: mainPhotoInfo?.introduceContent || '대표문구를 작성해주세요',
-        }}
-      />
-      <div
-        className={`flex justify-center items-center w-full ${mainViewType.type === 'fill' ? 'px-0' : 'px-[20px]'} `}
-      >
-        {!mainPhotoInfo?.imageUrl ? (
-          <p className='text-gray-500 w-[375px] h-[728px] bg-gray text-center'>이미지가 업로드되지 않았습니다.</p>
-        ) : (
-          <div
-            className='flex justify-center items-center relative w-full h-[600px]'
-            ref={previewRef}
-            onDrop={preventDefaultBehaviour}
-            onDragOver={preventDefaultBehaviour}
-          >
-            <Image
-              src={mainPhotoInfo.imageUrl}
-              alt='mainImg'
-              objectFit='cover'
-              fill
-              className='z-0'
-            />
-            <div className='absolute inset-0 flex justify-center items-center'>
-              {mainViewType.type === 'arch' && <ArchSvg color={svgBgColor} />}
-              {mainViewType.type === 'ellipse' && <EllipseSvg color={svgBgColor} />}
-            </div>
-            {stickersWatch?.map((sticker) => (
-              <Sticker
-                key={sticker.id}
-                sticker={sticker}
-                previewRef={previewRef}
-                activeStickerId={activeStickerId}
-                onActivate={handleActiveSticker}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-      <div className='flex justify-center items-center gap-2 mt-4'>
-        <p className='text-xl'>{mainPhotoInfo?.leftName || '좌측 이름'}</p>
-        <p className='text-xl'>{mainPhotoInfo?.icon || '♥︎'}</p>
-        <p className='text-xl'>{mainPhotoInfo?.rightName || '우측 이름'}</p>
-      </div>
-    </div>
+    <MainPhoto
+      mainPhotoInfo={mainPhotoInfo}
+      bgColor={svgBgColor}
+      mainView={mainViewType}
+      stickers={stickers}
+    />
   );
 };
 

--- a/src/components/create/preview/NavigationDetailsPreview.tsx
+++ b/src/components/create/preview/NavigationDetailsPreview.tsx
@@ -1,41 +1,23 @@
-import MapView from '@/components/map/MapView';
 import { InvitationFormType } from '@/types/invitationFormType.type';
 import { Control, useWatch } from 'react-hook-form';
-import NavigationDetailCard from '../NavigationDetailCard';
-import NavigationButtons from '../NavigationButtons';
+import NavigationDetails from '@/components/card/NavigationDetails';
 
 const NavigationDetailsPreview = ({ control }: { control: Control<InvitationFormType> }) => {
   const navigationDetail = useWatch({
     control,
     name: 'navigationDetail',
   });
-  const weddingInfoWatch = useWatch({
+
+  const weddingInfo = useWatch({
     control,
     name: 'weddingInfo',
   });
+
   return (
-    <>
-      <div>NavigationDetailsPreview</div>
-      {navigationDetail.map && <MapView address={weddingInfoWatch.weddingHallAddress} />}
-      {navigationDetail.navigationButton && (
-        <NavigationButtons
-          address={weddingInfoWatch.weddingHallAddress}
-          name={weddingInfoWatch.weddingHallName}
-        />
-      )}
-      {navigationDetail.bus && (
-        <NavigationDetailCard
-          label={'버스'}
-          info={navigationDetail.bus}
-        />
-      )}
-      {navigationDetail.subway && (
-        <NavigationDetailCard
-          label={'지하철'}
-          info={navigationDetail.subway}
-        />
-      )}
-    </>
+    <NavigationDetails
+      navigationDetail={navigationDetail}
+      weddingInfo={weddingInfo}
+    />
   );
 };
 

--- a/src/components/create/preview/PersonalInfoPreView.tsx
+++ b/src/components/create/preview/PersonalInfoPreView.tsx
@@ -1,63 +1,15 @@
 'use client';
 import { Control, useWatch } from 'react-hook-form';
-import PersonalInfoCard from '../PersonalInfoCard';
 import { InvitationFormType } from '@/types/invitationFormType.type';
+import PersonalInfoOnSharedCard from '@/components/card/PersonalInfoOnSharedCard';
 
 const PersonalInfoPreview = ({ control }: { control: Control<InvitationFormType> }) => {
-  const personaInfoWatch = useWatch({
+  const personalInfo = useWatch({
     control,
     name: 'personalInfo',
   });
 
-  const { bride, groom } = personaInfoWatch;
-
-  return (
-    <div className='flex flex-col justify-center items-center gap-[30px]'>
-      <div className='flex gap-[50px]'>
-        <div className='flex flex-col gap-[30px]'>
-          <div className='flex flex-col justify-center items-center'>
-            <PersonalInfoCard
-              label={groom.relation}
-              name={groom.name}
-              phoneNumber={groom.phoneNumber}
-            />
-          </div>
-          <p className='text-center'>신랑 측 혼주</p>
-          <PersonalInfoCard
-            label={groom.father.relation}
-            name={groom.father.isDeceased ? `故 ${groom.father.name}` : groom.father.name}
-            phoneNumber={groom.father.phoneNumber}
-          />
-          <PersonalInfoCard
-            label={groom.mother.relation}
-            name={groom.mother.isDeceased ? `故 ${groom.mother.name}` : groom.mother.name}
-            phoneNumber={groom.mother.phoneNumber}
-          />
-        </div>
-
-        <div className='flex flex-col gap-[30px]'>
-          <div className='flex flex-col justify-center items-center'>
-            <PersonalInfoCard
-              label={bride.relation}
-              name={bride.name}
-              phoneNumber={bride.phoneNumber}
-            />
-          </div>
-          <p className='text-center'>신부 측 혼주</p>
-          <PersonalInfoCard
-            label={bride.father.relation}
-            name={bride.father.isDeceased ? `故 ${bride.father.name}` : bride.father.name}
-            phoneNumber={bride.father.phoneNumber}
-          />
-          <PersonalInfoCard
-            label={bride.mother.relation}
-            name={bride.mother.isDeceased ? `故 ${bride.mother.name}` : bride.mother.name}
-            phoneNumber={bride.mother.phoneNumber}
-          />
-        </div>
-      </div>
-    </div>
-  );
+  return <PersonalInfoOnSharedCard personalInfo={personalInfo} />;
 };
 
 export default PersonalInfoPreview;

--- a/src/components/create/preview/WeddingInfoPreView.tsx
+++ b/src/components/create/preview/WeddingInfoPreView.tsx
@@ -1,23 +1,14 @@
 import { Control, useWatch } from 'react-hook-form';
 import { InvitationFormType } from '@/types/invitationFormType.type';
+import WeddingInfo from '@/components/card/WeddingInfo';
 
 const WeddingInfoPreView = ({ control }: { control: Control<InvitationFormType> }) => {
-  const weddingInfoWatch = useWatch({
+  const weddingInfo = useWatch({
     control,
     name: 'weddingInfo',
   });
 
-  return (
-    <div>
-      웨딩 정보 입력 미리보기 영역
-      <p>날짜: {weddingInfoWatch?.date}</p>
-      <p>{weddingInfoWatch.time.hour}시</p>
-      <p>{weddingInfoWatch.time.minute}분</p>
-      <p>예식장 주소: {weddingInfoWatch.weddingHallAddress}</p>
-      <p>예식장 이름: {weddingInfoWatch.weddingHallName}</p>
-      <p>연락처: {weddingInfoWatch.weddingHallContact}</p>
-    </div>
-  );
+  return <WeddingInfo weddingInfo={weddingInfo} />;
 };
 
 export default WeddingInfoPreView;

--- a/src/components/guestbook/GuestBook.tsx
+++ b/src/components/guestbook/GuestBook.tsx
@@ -3,19 +3,18 @@
 import useGuestBookEntries from '@/hooks/guestbook/useGuestBookEntries';
 import CreateGuestBook from './CreateGuestBook';
 import GuestBookCard from './GuestBookCard';
+import useInvitationIdByPathname from '@/hooks/invitation/useInvitationIdByPathname';
 
 const GuestBook = () => {
-  const invitationId = '6ae529a2-725d-4e2d-ac26-07bd9e86aa34'; // @TODO 추후 청첩장 id를 넣는 방식으로 변경
-
+  const { invitationId } = useInvitationIdByPathname();
   const { data: guestBooks = [], isLoading, error } = useGuestBookEntries(invitationId);
-
   if (isLoading) return <div>방명록을 로딩중입니다...</div>;
   if (error) return <div>방명록을 불러오는 중 에러가 발생하였습니다.</div>;
 
   return (
     <div>
       <div className='text-center'>GUEST BOOK</div>
-      <CreateGuestBook invitationId={invitationId}/>
+      <CreateGuestBook invitationId={invitationId} />
       <div>
         {guestBooks.map((guestBook) => (
           <GuestBookCard

--- a/src/components/layouts/Navigation.tsx
+++ b/src/components/layouts/Navigation.tsx
@@ -32,7 +32,6 @@ const Navigation = ({ initialAuthState }: { initialAuthState: boolean }) => {
   return (
     <nav className='flex gap-3 justify-center items-center'>
       <LinkToReviewPage />
-      <button onClick={() => Notify.success('check')}>click</button>
       {isAuthenticated ? (
         <>
           <LinkToMypage />

--- a/src/components/mypage/TogglePrivate.tsx
+++ b/src/components/mypage/TogglePrivate.tsx
@@ -3,6 +3,7 @@ import { QUERY_KEYS } from '@/hooks/queries/queryKeys';
 import { getInvitationCard, patchPrivateInvitation } from '@/utils/myPage';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
+import { revalidateInvitation } from '@/utils/revalidateInvitation';
 
 const TogglePrivate = () => {
   const [isPrivate, setIsPrivate] = useState(false);
@@ -33,10 +34,12 @@ const TogglePrivate = () => {
     },
   });
 
-  const toggleSwitch = () => {
+  const toggleSwitch = async () => {
+    if (!invitationCard || invitationCard.length < 1) return;
     const newIsPrivate = !isPrivate;
     setIsPrivate(newIsPrivate);
     mutation.mutate(newIsPrivate);
+    await revalidateInvitation(invitationCard[0].id);
   };
 
   if (isLoading) return <div>Loading...</div>;

--- a/src/hooks/invitation/useInvitationIdByPathname.ts
+++ b/src/hooks/invitation/useInvitationIdByPathname.ts
@@ -1,0 +1,11 @@
+import { usePathname } from 'next/navigation';
+
+const SAMPLE_GUESTBOOK_ID = 'ce7fe66a-0734-4314-9bd3-6fd8662621db';
+const useInvitationIdByPathname = () => {
+  const path = usePathname();
+  const invitationId = path === '/create/card' ? SAMPLE_GUESTBOOK_ID : path.split('/')[2];
+
+  return { invitationId };
+};
+
+export default useInvitationIdByPathname as typeof useInvitationIdByPathname;

--- a/src/types/invitationFormType.type.ts
+++ b/src/types/invitationFormType.type.ts
@@ -100,3 +100,11 @@ export type InvitationFormType = {
   mainPhotoInfo: MainPhotoType;
   isPrivate: boolean;
 };
+
+export type InvitationCard = {
+  main_photo_info: {
+    imageUrl: string;
+  };
+  isPrivate: boolean;
+  id: string;
+};

--- a/src/utils/myPage.ts
+++ b/src/utils/myPage.ts
@@ -1,8 +1,8 @@
-import { InvitationFormType } from '@/types/invitationFormType.type';
+import { InvitationCard } from '@/types/invitationFormType.type';
 import { getUserInfo } from './server-action';
 import { supabase } from './supabase/createClient';
 
-export const getInvitationCard = async (): Promise<InvitationFormType[] | null> => {
+export const getInvitationCard = async (): Promise<InvitationCard[] | null> => {
   const user = await getUserInfo();
   const userId = user?.user.id;
   const { data, error } = await supabase.from('invitation').select('*').eq('user_id', userId);
@@ -12,7 +12,7 @@ export const getInvitationCard = async (): Promise<InvitationFormType[] | null> 
     return null;
   }
 
-  return data as InvitationFormType[];
+  return data as unknown as InvitationCard[];
 };
 
 export const patchPrivateInvitation = async (isPrivate: boolean) => {
@@ -23,5 +23,5 @@ export const patchPrivateInvitation = async (isPrivate: boolean) => {
     console.error('초대장 상태 업데이트 실패:', error);
     return null;
   }
-  return data;
+  return data as unknown as InvitationCard[];
 };

--- a/src/utils/revalidateInvitation.ts
+++ b/src/utils/revalidateInvitation.ts
@@ -1,0 +1,10 @@
+export const revalidateInvitation = async (invitationId: string) => {
+  const response = await fetch(`/api/revalidate/${invitationId}`);
+  const data = await response.json();
+
+  if (response.ok) {
+    console.log('업데이트 성공');
+  } else {
+    return console.log(data.message || '업데이트 실패');
+  }
+};

--- a/src/utils/revalidateInvitation.ts
+++ b/src/utils/revalidateInvitation.ts
@@ -1,5 +1,5 @@
 export const revalidateInvitation = async (invitationId: string) => {
-  const response = await fetch(`/api/revalidate/${invitationId}`);
+  const response = await fetch(`/api/revalidate?id=${invitationId}`);
   const data = await response.json();
 
   if (response.ok) {

--- a/src/utils/revalidateInvitation.ts
+++ b/src/utils/revalidateInvitation.ts
@@ -1,10 +1,15 @@
+import { Notify } from 'notiflix';
+
 export const revalidateInvitation = async (invitationId: string) => {
   const response = await fetch(`/api/revalidate?id=${invitationId}`);
   const data = await response.json();
 
   if (response.ok) {
-    console.log('업데이트 성공');
-  } else {
-    return console.log(data.message || '업데이트 실패');
+    Notify.success('청첩장 공개가 전환되었습니다.');
+  }
+
+  if (!response.ok) {
+    console.error(data.message || '업데이트 실패');
+    throw new Error(data.message);
   }
 };


### PR DESCRIPTION
## ✅ 작업 사항

- 청첩장 데이터를 보여주는 곳을 프리뷰 컴포넌트에서 분리해 공유된 청첩장을 보여주는 곳에서 재사용
- card/청첩장ID 페이지를 SSG 방식으로 렌더링
- 사용자가 마이페이지에서 청첩장 공개여부를 수정하는 경우 revalidatePath 이용해 캐시 무효화
- revalidate 성공한 경우 토스트메세지로 알려줌

## 📸 스크린샷
![미리보기](https://github.com/user-attachments/assets/65f22412-a2f4-4cc2-abde-5a0e4a741188)

![스크린샷 2024-11-01 오후 4 13 26](https://github.com/user-attachments/assets/6333c048-67d1-43dd-b1c6-8aad44342fdc)
- 카드 작성 페이지에서는 샘플 방명록이 나옵니다

![무효화토스트](https://github.com/user-attachments/assets/4d0259ce-5396-42cb-b9e2-942cacc03006)
- revalidatePath 요청 성공시 토스트 메세지 출력

<br/>

## 🧑‍💻 기타

- 현재 공개 여부 수정에만 revalidatePath 적용돼있습니다!
- 카드 작성 페이지에서는 샘플 방명록이 나옵니다
- 공유된 청첩장에서는 스티커 선택이 되지 않습니다
- 위 상황들처럼 프리뷰/공유청첩장에서 다르게 동작해야하는 경우가 있다면 추가로 알려주세요!!

- 프리뷰 컴포넌트 수정하시는 경우에 프리뷰에 들어가있는 컴포넌트로 들어가서 그대로 적용해주시면 됩니다!!
- Ex. accout preview를 수정하려는 경우
<img width="1345" alt="image" src="https://github.com/user-attachments/assets/e3d9fe17-6548-4a8e-a51a-9b344507f57c">

기존 AccountPreview.tsx에 가시면 Account와 같은 컴포넌트가 있습니다

<img width="898" alt="image" src="https://github.com/user-attachments/assets/714caa96-ebca-4302-baab-e20f79c2f23d">

Account.tsx로 타고 들어가시면 기존에 구현하셨던 jsx 부분이 그대로 들어가있습니다!
거기에 똑같이 반영해주시면 돼요!