### PR TITLE
fix: 벡터이미지 아치형 이미지 끝에 안오는 현상 수정

### DIFF
--- a/src/components/create/CustomSVG.tsx
+++ b/src/components/create/CustomSVG.tsx
@@ -6,9 +6,11 @@ export const ArchSvg = ({ color }: { color: ColorType }) => {
     <svg
       width='100%'
       height='100%'
-      viewBox='0 190 343 172'
+      viewBox='0 0 343 172'
       fill='none'
       xmlns='http://www.w3.org/2000/svg'
+      preserveAspectRatio='xMinYMin meet'
+      style={{ display: 'block' }}
     >
       <path
         fillRule='evenodd'


### PR DESCRIPTION
## ✅ 작업 사항

- 아치형 벡터이미지 위치 수정


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/6beae2fa-da9a-425e-98a2-bbdfb0e04355)

<br/>

## 🧑‍💻 기타

-
