### PR TITLE
Feat/preview order: 프리뷰 순서바꾸기

### DIFF
--- a/src/app/create/card/page.tsx
+++ b/src/app/create/card/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { InvitationFormType } from '@/types/invitationFormType.type';
 import { debounce } from '@/utils/debounce';
 import { useGetInvitationQuery } from '@/hooks/queries/invitation/useGetInvitationQuery';
@@ -43,7 +43,14 @@ const CreateCardPage = () => {
   const [nameIndex, setNameIndex] = useState<number>(0);
   const [inputIndex, setInputIndex] = useState<number>(0);
   const [isRendered, setIsRendered] = useState<boolean>(false);
-  const orderList = INITIAL_ORDER(methods);
+  const [orderList, setOrderList] = useState(() => INITIAL_ORDER(methods));
+  const renderOrderList = useWatch({ control: methods.control, name: 'renderOrder' });
+  const sortedOrderListWithRenderOrder = orderList.sort((a, b) => {
+    const orderA = renderOrderList.find((item) => item.typeOnSharedCard === a.typeOnSharedCard)?.order;
+    const orderB = renderOrderList.find((item) => item.typeOnSharedCard === b.typeOnSharedCard)?.order;
+
+    return (orderA ?? a.order) - (orderB ?? b.order);
+  });
 
   const refs = useRef<null[] | HTMLDivElement[]>([]);
   const { isNavigating, initializeObserver, unsubscribeObservers } = useIntersectionObserver(
@@ -160,6 +167,16 @@ const CreateCardPage = () => {
     }, DELAY_TIME); // 스크롤 애니메이션 지속 시간 후 재활성화
   };
 
+  useEffect(() => {
+    setOrderList(
+      sortedOrderListWithRenderOrder.map((e, index) => {
+        return {
+          ...e,
+          order: index,
+        };
+      }),
+    );
+  }, [renderOrderList]);
   useEffect(() => {
     setIsRendered(true);
   }, []);

--- a/src/hooks/observer/useIntersectionObserver.ts
+++ b/src/hooks/observer/useIntersectionObserver.ts
@@ -9,7 +9,7 @@ type ObserverOptions = {
 const DEFAULT_OPTIONS: ObserverOptions = {
   root: null,
   rootMargin: '0px',
-  threshold: 0.9,
+  threshold: 0.65,
 };
 
 export const useIntersectionObserver = (


### PR DESCRIPTION
## ✅ 작업 사항

- 제작 화면에서 순서를 바꿨을 때 미리보기도 순서가 바뀌도록 구현했습니다.


## 📸 스크린샷
![드림카드 _ 나만의 모바일 청첩장 - Chrome 2024-11-06 01-01-50](https://github.com/user-attachments/assets/2afe878f-9c4b-4cb8-86cf-28a62d185872)

<br/>

## 🧑‍💻 기타

- 순서를 바꿀때 화면도 같이 스크롤이 되는건지 딸려올라가는 현상을 수정해야할것같습니다.
