### PR TITLE
fix: 리뷰 상세 페이지 이메일 회원가입시 이름 안나오던 오류 수정

### DIFF
--- a/src/app/review/[id]/page.tsx
+++ b/src/app/review/[id]/page.tsx
@@ -1,6 +1,7 @@
 import ReviewContentsBox from '@/components/review/ReviewContentsBox';
 import ReviewSlide from '@/components/review/ReviewSlide';
 import { MOBILE_VIEW_HEIGHT } from '@/constants/screenSize';
+import { getAuthUsersProfile } from '@/utils/getReview';
 import { getReviewDetail } from '@/utils/server-action';
 
 interface ParamsType {
@@ -18,6 +19,8 @@ type ReviewType = {
 
 const ReviewDetailPage = async ({ params }: { params: ParamsType }) => {
   const reviewData: ReviewType = await getReviewDetail(params.id);
+  const users = await getAuthUsersProfile();
+  const reviewUser = users.users.find((e) => e.id === reviewData.user_id);
 
   return (
     <div
@@ -28,7 +31,7 @@ const ReviewDetailPage = async ({ params }: { params: ParamsType }) => {
 
       <div className='absolute inset-0 bg-gradient-to-b from-transparent to-black opacity-60'></div>
       <ReviewContentsBox
-        writer={reviewData.user_name!}
+        user={reviewUser!}
         content={reviewData.content}
         created={reviewData.created_at}
         avatar_url={reviewData.avatar_url}

--- a/src/components/review/ReviewContentsBox.tsx
+++ b/src/components/review/ReviewContentsBox.tsx
@@ -1,14 +1,16 @@
 'use client';
+import { User } from '@/types/users.types';
+import { maskIdLastFour } from '@/utils/maskIdLastFour';
 import Image from 'next/image';
 import { useState } from 'react';
 type PropsType = {
-  writer: string;
   content: string;
   created: string;
   avatar_url: string | null;
+  user: User;
 };
 const MAX_CONTENT_LENGTH = 50 as const;
-const ReviewContentsBox = ({ writer, content, created, avatar_url }: PropsType) => {
+const ReviewContentsBox = ({ content, created, avatar_url, user }: PropsType) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   const convertedCreatedDate = new Date(created)
@@ -37,7 +39,8 @@ const ReviewContentsBox = ({ writer, content, created, avatar_url }: PropsType) 
           alt='default'
           className='rounded-full'
         />
-        <p className='pl-[8px]'>{writer}</p> <p className='px-[4px]'>|</p> <span>{convertedCreatedDate}</span>
+        <p className='pl-[8px]'>{maskIdLastFour(user.user_metadata.email!)}</p> <p className='px-[4px]'>|</p>
+        <span>{convertedCreatedDate}</span>
       </div>
       <div className='flex flex-col mt-[14px] mb-[8px]'>
         <p className='break-words text-[12px]'>{sliceContent(content)}</p>


### PR DESCRIPTION
## ✅ 작업 사항

- 포토리뷰 상세에서 이메일 가입 회원은 이름 안나오던 오류 수정했습니다.


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/61e35589-0470-405a-a62e-76417cd2e036)

<br/>

## 🧑‍💻 기타

-
