### PR TITLE
Fix/sticker touch bug: 메인화면 순서 고정, 크기가 작은 스티커 기본 사이즈 확대

### DIFF
--- a/src/components/create/DraggableRenderOrder.tsx
+++ b/src/components/create/DraggableRenderOrder.tsx
@@ -52,7 +52,7 @@ const DraggableRenderOrder = ({
   return (
     <div
       ref={combinedRef}
-      className={`${isDragging && 'opacity-50'} flex justify-start items-center gap-[8px] h-[24px] text-[16px] text-gray-800 font-main font-medium mb-[10px]`}
+      className={`${isDragging && 'opacity-50'} flex justify-start items-center gap-[8px] h-[30px] text-[16px] text-gray-800 font-main font-medium mb-[10px]`}
     >
       <img
         src='/assets/images/icons/equals.webp'

--- a/src/components/create/RenderOrderInput.tsx
+++ b/src/components/create/RenderOrderInput.tsx
@@ -38,11 +38,13 @@ const RenderOrderInput = () => {
   );
 
   return (
-    <div className='mb-[15px] h-[204px]'>
+    <div className='mt-[10px] h-[204px]'>
       <RenderOrderCustomPreview />
       <div>
         {sortedRenderOrder.map((option) => {
-          if (option.labelForInput === 'ONLY_FOR_CREATE') return;
+          if (option.typeOnSharedCard === 'MAIN_PHOTO') return;
+          if (option.typeOnSharedCard === 'ONLY_FOR_CREATE') return;
+
           return (
             <DraggableRenderOrder
               key={option.labelForInput}

--- a/src/components/create/stickerInput/Sticker.tsx
+++ b/src/components/create/stickerInput/Sticker.tsx
@@ -209,6 +209,8 @@ const Sticker = ({
           position: 'absolute',
           top: `${sticker.posY}%`,
           left: `${sticker.posX}%`,
+          width: `${sticker.width}`,
+          height: `${sticker.height}`,
           transform: `rotate(${sticker.rotation}deg)`,
         }}
       >
@@ -241,7 +243,6 @@ const Sticker = ({
             <img
               src={sticker.url}
               alt={sticker.stickerImageId}
-              style={{ width: sticker.width, height: sticker.height }}
               className={`${isActive && 'border-[1px] border-primary-300'} w-full h-full`}
               onTouchStart={handleTouchStart}
               onTouchEnd={handleTouchEnd}

--- a/src/components/create/stickerInput/StickerSlot.tsx
+++ b/src/components/create/stickerInput/StickerSlot.tsx
@@ -20,10 +20,10 @@ const StickerSlot = ({ stickerImage }: PropsType) => {
       id: `${crypto.randomUUID()}-${stickerImage.id}`,
       url: `${stickerImage.url}`,
       stickerImageId: stickerImage.id,
-      posX: '0',
-      posY: '0',
-      width: stickerImage.width,
-      height: stickerImage.height,
+      posX: '5',
+      posY: '5',
+      width: stickerImage.width < 100 ? +stickerImage.width * 3 : stickerImage.width,
+      height: stickerImage.width < 100 ? +stickerImage.height * 3 : stickerImage.height,
       rotation: 0,
     });
 


### PR DESCRIPTION
## ✅ 작업 사항

- 메인화면 순서 변경에서 제외
- 크기가 작은 스티커가 (width < 100) 기본 생성될 때 크기 조정
