### PR TITLE
fix: card 페이지 중앙정렬

### DIFF
--- a/src/app/card/[id]/page.tsx
+++ b/src/app/card/[id]/page.tsx
@@ -62,7 +62,7 @@ const CardPage = async ({ params }: { params: { id: string } }) => {
   const canView = userId === invitationData.userId || !isPrivate;
   return canView ? (
     <div
-      className='flex flex-col gap-[56px] max-w-[375px]'
+      className='flex flex-col gap-[56px] max-w-[375px] mx-auto'
       style={{
         backgroundColor: `rgba(${bgColor.r}, ${bgColor.g}, ${bgColor.b}, ${bgColor.a})`,
         fontFamily: `${fontStyle || 'main'}`,


### PR DESCRIPTION
## ✅ 작업 사항

- 카드페이지 중앙정렬 설정
- 지금까지 레이아웃이 다른 페이지랑 같이 있어서 문제없었는데 create/card랑 분리되어 페이지 내부에서 중앙정렬했습니다!
