### PR TITLE
fix: 데스크탑일 때 faq 결과 텍스트 사이즈 조정

### DIFF
--- a/src/components/create/modal/KakaoPayModal.tsx
+++ b/src/components/create/modal/KakaoPayModal.tsx
@@ -12,7 +12,7 @@ type ModalProps = {
 const KakaoPayModal: React.FC<ModalProps> = ({ isModalOpen, onClose, onSave, children }) => {
   const { isFlipped, toggleFlip } = usePayModalFlip();
 
-  if (!isModalOpen) return <></>;
+  if (!isModalOpen) return null;
 
   return (
     <div

--- a/src/components/main/FaqCard.tsx
+++ b/src/components/main/FaqCard.tsx
@@ -1,6 +1,6 @@
 const FaqCard = ({ answer }: { answer: string }) => {
   return (
-    <div className='text-gray-800 text-[12px] bg-gray-50 w-full p-4'>
+    <div className='text-gray-800 text-[12px] desktop:text-[14px] bg-gray-50 w-full p-4'>
       <div className='flex gap-4'>
         <div className='w-[40px] h-[40px] relative flex-shrink-0'>
           <img


### PR DESCRIPTION
## ✅ 작업 사항

- faq 데스크탑에서 확인 시 글씨 크기가 작아서 수정하였습니다.


## 📸 스크린샷
- 기존
![image](https://github.com/user-attachments/assets/4e1b6074-7618-4dae-afed-514af4b12728)
- 수정
![image](https://github.com/user-attachments/assets/f77dd696-9de8-43ad-9b51-d63da65437ff)
<br/>

## 🧑‍💻 기타

- 카카오페이 모달 오픈이 아닐 시 <></>에서 null로 다시 수정하였습니다.
