### PR TITLE
Fix/review detail carousel : 후기 상세 슬라이드 버튼 수정

### DIFF
--- a/src/components/review/ReviewForm.tsx
+++ b/src/components/review/ReviewForm.tsx
@@ -118,7 +118,7 @@ const ReviewForm = () => {
       </div>
       <div className='relative w-full mt-[14px] h-[184px]'>
         <textarea
-          className='w-full h-full rounded-[12px] border-[1px] border-gray-200 p-[16px] resize-none text-[12px] text-gray-700'
+          className='w-full h-full rounded-[12px] border-[1px] border-gray-200 p-[16px] resize-none text-[14px] text-gray-700'
           maxLength={200}
           placeholder='리뷰를 입력해주세요.'
           {...register('content')}

--- a/src/components/review/ReviewSlide.tsx
+++ b/src/components/review/ReviewSlide.tsx
@@ -5,6 +5,8 @@ import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 
 const ReviewSlide = ({ images }: { images: string[] }) => {
   const [currentIndex, setCurrentIndex] = useState<number>(0);
+  const isFirstImage = currentIndex === 0;
+  const isLastImage = currentIndex === images.length - 1;
   const handleNext = () => {
     setCurrentIndex((prevIndex) => (prevIndex + 1) % images.length);
   };
@@ -22,18 +24,22 @@ const ReviewSlide = ({ images }: { images: string[] }) => {
         className='object-cover'
         priority
       />
-      <button
-        onClick={() => handlePrevious()}
-        className='absolute flex items-center justify-center left-4 top-1/2 transform -translate-y-1/2 bg-black/60 text-white px-4 py-2 rounded-full z-50 w-[40px] h-[40px] desktop:w-[70px] desktop:h-[70px] desktop:left-[-100px]'
-      >
-        <FaChevronLeft className='w-[28px] h-[28px] desktop:w-[32px] desktop:h-[32px]' />
-      </button>
-      <button
-        onClick={() => handleNext()}
-        className='flex items-center justify-center absolute right-4 top-1/2 transform -translate-y-1/2 bg-black/60 text-white px-4 py-2 rounded-full z-50 w-[40px] h-[40px] desktop:w-[70px] desktop:h-[70px] desktop:right-[-100px] '
-      >
-        <FaChevronRight className='w-[28px] h-[28px] desktop:w-[32px] desktop:h-[32px]' />
-      </button>
+      {!isFirstImage && (
+        <button
+          onClick={() => handlePrevious()}
+          className='absolute flex items-center justify-center left-4 top-1/2 transform -translate-y-1/2 bg-black/60 text-white px-4 py-2 rounded-full z-50 w-[40px] h-[40px] desktop:w-[70px] desktop:h-[70px] desktop:left-[-100px]'
+        >
+          <FaChevronLeft className='w-[28px] h-[28px] desktop:w-[32px] desktop:h-[32px]' />
+        </button>
+      )}
+      {!isLastImage && (
+        <button
+          onClick={() => handleNext()}
+          className='flex items-center justify-center absolute right-4 top-1/2 transform -translate-y-1/2 bg-black/60 text-white px-4 py-2 rounded-full z-50 w-[40px] h-[40px] desktop:w-[70px] desktop:h-[70px] desktop:right-[-100px] '
+        >
+          <FaChevronRight className='w-[28px] h-[28px] desktop:w-[32px] desktop:h-[32px]' />
+        </button>
+      )}
     </>
   );
 };

--- a/src/components/review/ReviewWriteBottomSheet.tsx
+++ b/src/components/review/ReviewWriteBottomSheet.tsx
@@ -12,7 +12,7 @@ const ReviewWriteBottomSheet = () => {
       initial={{ y: '100%' }}
       animate={{ y: 0 }}
       transition={{ stiffness: 100 }}
-      className='fixed bottom-0 inset-x-0 mx-auto w-[375px] desktop:w-full h-[555px] p-[16px] pb-[27px] rounded-t-[24px] z-50 flex flex-col items-center justify-end bg-white shadow-lg'
+      className='fixed bottom-0 inset-x-0 mx-auto max-w-[375px] desktop:w-full h-[555px] p-[16px] pb-[27px] rounded-t-[24px] z-50 flex flex-col items-center justify-end bg-white shadow-lg'
       style={{ transform: 'translateY(0%)' }}
     >
       <button

--- a/src/components/review/ReviewWriteBottomSheet.tsx
+++ b/src/components/review/ReviewWriteBottomSheet.tsx
@@ -12,7 +12,7 @@ const ReviewWriteBottomSheet = () => {
       initial={{ y: '100%' }}
       animate={{ y: 0 }}
       transition={{ stiffness: 100 }}
-      className='fixed bottom-0 inset-x-0 mx-auto max-w-[375px] desktop:w-full h-[555px] p-[16px] pb-[27px] rounded-t-[24px] z-50 flex flex-col items-center justify-end bg-white shadow-lg'
+      className='fixed bottom-0 inset-x-0 mx-auto max-w-[375px] h-[555px] p-[16px] pb-[27px] rounded-t-[24px] z-50 flex flex-col items-center justify-end bg-white shadow-lg'
       style={{ transform: 'translateY(0%)' }}
     >
       <button

--- a/src/components/review/ReviewWriteBottomSheet.tsx
+++ b/src/components/review/ReviewWriteBottomSheet.tsx
@@ -12,7 +12,7 @@ const ReviewWriteBottomSheet = () => {
       initial={{ y: '100%' }}
       animate={{ y: 0 }}
       transition={{ stiffness: 100 }}
-      className='fixed bottom-0 inset-x-0 mx-auto w-full h-[555px] p-[16px] pb-[27px] rounded-t-[24px] z-50 flex flex-col items-center justify-end bg-white shadow-lg'
+      className='fixed bottom-0 inset-x-0 mx-auto w-[375px] desktop:w-full h-[555px] p-[16px] pb-[27px] rounded-t-[24px] z-50 flex flex-col items-center justify-end bg-white shadow-lg'
       style={{ transform: 'translateY(0%)' }}
     >
       <button

--- a/src/components/review/ReviewWriteButton.tsx
+++ b/src/components/review/ReviewWriteButton.tsx
@@ -69,7 +69,7 @@ const ReviewWriteButton = () => {
     <>
       <button
         className='fixed bottom-[12px] left-1/2 rounded-[300px] bg-primary300
-    text-white flex justify-center items-center w-[150px] h-[40px] -translate-x-1/2 gap-[6px] px-[16px]
+    text-white flex justify-center items-center w-[150px] h-[40px] -translate-x-1/2 gap-[6px] px-[16px] z-10
     '
         onClick={handleOpenReviewWrite}
       >


### PR DESCRIPTION
## ✅ 작업 사항

- 이미지 개수에 따른 next prev버튼 유무 수정했습니다
- 푸터 아이콘 z-index에 후기 작성 버튼 z-index가 밀려서 z-index추가했습니다
- 후기 작성 바텀시트 크기가 화면 전체를 가져와서 max width 설정하였습니다


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/fd4a6842-054f-4545-8bf3-c0a3016c5fd1)
![image](https://github.com/user-attachments/assets/0d8cf49d-a840-4222-8e34-4a1e6a03d552)
![image](https://github.com/user-attachments/assets/cf51cce7-aa5c-4d02-8f31-db6418ef98d4)
![image](https://github.com/user-attachments/assets/e72dae2f-89af-456a-a593-4b80b716aaaa)

<br/>

## 🧑‍💻 기타

-
