### PR TITLE
Style/desktop design qa: 예식정보, 컬러팔레트 데스크탑 디자인 QA 반영 / 메인 캐러셀 시작 위치 조정

### DIFF
--- a/src/components/create/ColorPalette.tsx
+++ b/src/components/create/ColorPalette.tsx
@@ -29,7 +29,7 @@ const ColorPalette: React.FC<ColorPaletteProps> = ({ selectedColor, onChangeColo
   }, []);
 
   return (
-    <div className='grid grid-cols-5 place-content-center place-items-center text-sm gap-y-[27px] desktop:w-[391px]'>
+    <div className='grid grid-cols-5 place-content-center place-items-center text-sm desktop:gap-x-[54px] gap-y-[27px] desktop:w-[398.5px]'>
       <div className='flex-col-center'>
         <button
           type='button'
@@ -42,7 +42,7 @@ const ColorPalette: React.FC<ColorPaletteProps> = ({ selectedColor, onChangeColo
             className='w-[27px] h-[27px] rounded-full bg-gray-200'
           />
         </button>
-        <p className='mt-[12px] text-[#737373]'>원본</p>
+        <p className='mt-[12px] text-[#737373] whitespace-nowrap'>원본</p>
       </div>
 
       {COLOR_DEFAULT_PALETTE.map((colorElement) => (
@@ -62,7 +62,7 @@ const ColorPalette: React.FC<ColorPaletteProps> = ({ selectedColor, onChangeColo
               }}
             />
           </button>
-          <p className='mt-[12px] text-[#737373]'>{colorElement.name}</p>
+          <p className='mt-[12px] text-[#737373] whitespace-nowrap text-center'>{colorElement.name}</p>
         </div>
       ))}
 
@@ -80,7 +80,7 @@ const ColorPalette: React.FC<ColorPaletteProps> = ({ selectedColor, onChangeColo
             alt='직접선택'
           />
         </button>
-        <p className='mt-[12px] text-[#737373]'>직접 선택</p>
+        <p className='mt-[12px] text-[#737373] whitespace-nowrap'>커스텀</p>
 
         {openModal &&
           portalElement &&

--- a/src/components/create/FontInput.tsx
+++ b/src/components/create/FontInput.tsx
@@ -66,7 +66,7 @@ const FontInput = () => {
           ))}
         </div>
       </div>
-      <div className='mt-[21px] desktop:flex desktop:justify-center desktop:mb-[4px]'>
+      <div className='mt-[16px] desktop:flex desktop:justify-center desktop:mb-[16px]'>
         <ColorPalette
           onChangeColor={(color) => handleFontColorChange(color)}
           selectedColor={fontColor}

--- a/src/components/create/WeddingInfoInput.tsx
+++ b/src/components/create/WeddingInfoInput.tsx
@@ -87,7 +87,7 @@ const WeddingInfoInput = () => {
       <div className='flex flex-col gap-[8px] text-[14px] text-gray-700 font-medium'>
         <div className='grid grid-cols-[80px_1fr]'>
           <label className='leading-[32px]'>주소</label>
-          <div className='grid grid-cols-[1fr_auto] gap-[8px]'>
+          <div className='grid grid-cols-[1fr_auto] desktop:grid-cols-[308px_1fr] gap-[8px]'>
             <input
               readOnly={true}
               placeholder='주소를 검색해주세요.'
@@ -95,7 +95,7 @@ const WeddingInfoInput = () => {
               {...register('weddingInfo.weddingHallAddress')}
             />
             <button
-              className='bg-primary-300 rounded-[8px] w-[56px] h-[32px] text-white font-bold text-[16px] tracking-[-0.032px]'
+              className='bg-primary-300 rounded-[8px] w-[56px] desktop:w-[72px] h-[32px] text-white font-bold text-[16px] tracking-[-0.032px]'
               onClick={openAddressModal}
               type='button'
             >
@@ -110,13 +110,14 @@ const WeddingInfoInput = () => {
             className='w-[235px] desktop:w-[388px] h-[32px] rounded-[8px] border-[.5px] border-gray-300 px-[8px] py-[9px]'
             {...register('weddingInfo.weddingHallName')}
             maxLength={21}
+            placeholder='예식장명을 입력해주세요.'
           />
         </div>
         <div className='grid grid-cols-[80px_1fr]'>
           <label className='text-[14px] text-gray-700 font-medium leading-[32px]'>연락처</label>
           <input
             className='w-[172px] desktop:w-[308px] h-[32px] rounded-[8px] border-[.5px] border-gray-300 px-[8px] py-[9px] text-gray-400 text-[12px]'
-            placeholder='연락처를 입력해주세요.'
+            placeholder='예식장 연락처를 입력해주세요.'
             {...register('weddingInfo.weddingHallContact')}
             maxLength={15}
           />

--- a/src/components/main/BrandingCarousel/BrandingCarousel.tsx
+++ b/src/components/main/BrandingCarousel/BrandingCarousel.tsx
@@ -25,7 +25,7 @@ const CAROUSEL_ITEM_PROPS = [
 ];
 
 const BrandingCarousel = () => {
-  const { currentIndex, isTransitioning } = useCarousel(CAROUSEL_ITEM_PROPS.length, 3000, 500);
+  const { currentIndex, isTransitioning } = useCarousel(CAROUSEL_ITEM_PROPS.length, 2700, 500);
   const indicatorBackgroundRef = useRef<HTMLDivElement | null>(null);
   const indicatorWidth = useMemo(
     () => (indicatorBackgroundRef.current?.offsetWidth ?? 0) / 3,

--- a/src/hooks/ui/useCarousel.ts
+++ b/src/hooks/ui/useCarousel.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 const useCarousel = (itemNumber: number, interval: number, duration: number) => {
-  const [currentIndex, setCurrentIndex] = useState(1);
+  const [currentIndex, setCurrentIndex] = useState(itemNumber - 1);
   const [isTransitioning, setIsTransitioning] = useState(true);
 
   const moveCarousel = () => {


### PR DESCRIPTION
## ✅ 작업 사항

- 인풋 데스크탑 디자인 반영
- 메인 캐러셀 이미지가 첫 이미지부터 시작하도록 조정 (기존에 마지막 이미지 보여주고 - 첫이미지부터 움직임 시작하는 형태였음)


## 📸 스크린샷
<img width="699" alt="image" src="https://github.com/user-attachments/assets/1067b60a-1690-41d0-baf1-9209bd0c4fed">
<img width="678" alt="image" src="https://github.com/user-attachments/assets/74baabaf-69ee-4149-a6c8-ea90b8521a43">

<br/>
